### PR TITLE
Add `generate-dataset` command to CLI for synthetic dataset generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,28 @@ mcp-doctor analyze [OPTIONS]
 - `--env-vars TEXT`: Environment variables for NPX command (JSON format)
 - `--working-dir TEXT`: Working directory for NPX command
 
+### `generate-dataset` Command
+Create synthetic datasets of MCP tool use cases using Claude or GPT models.
+
+```bash
+# Generate 8 tasks using tools fetched from a running server
+export ANTHROPIC_API_KEY=sk-ant-example
+mcp-doctor generate-dataset --target http://localhost:8000/mcp --num-tasks 8 --llm-timeout 90 --output dataset.json
+
+# Generate 8 tasks using tools from an NPX command
+export OPENAI_API_KEY=sk-open-example
+mcp-doctor generate-dataset --target "npx firecrawl-mcp" --num-tasks 8 --output dataset.json
+
+# Generate tasks from a local JSON definition using OpenAI
+export OPENAI_API_KEY=sk-open-example
+mcp-doctor generate-dataset --tools-file tools.json --num-tasks 5
+```
+
+Set either `ANTHROPIC_API_KEY` (Claude 4 Sonnet) or `OPENAI_API_KEY` (GPT-4.1) before
+running the command. The output is a JSON array containing `prompt`, `tools_called`, and
+`tools_args` entries ready for downstream evaluations. Use `--llm-timeout` to extend the
+wait for slower model responses when needed (defaults to 60 seconds).
+
 ### `version` Command
 Show version and diagnostic capabilities.
 

--- a/SOCIAL_MEDIA_TEMPLATES.md
+++ b/SOCIAL_MEDIA_TEMPLATES.md
@@ -1,0 +1,261 @@
+# Social Media Templates for MCP Doctor 📱
+
+## 🐦 Twitter/X Announcement Thread
+
+### Tweet 1 (Main Announcement)
+```
+🩺 Introducing MCP Doctor - the diagnostic tool for Model Context Protocol servers!
+
+Built for developers working with AI agents, MCP Doctor ensures your MCP servers are agent-friendly and follow best practices.
+
+✨ Lightning-fast analysis (no AI dependencies)
+🔒 Security-first with credential filtering  
+🌐 HTTP & NPX server support
+
+🧵 Thread 👇
+
+#OpenSource #Python #AI #MCP #DevTools
+```
+
+### Tweet 2 (Problem/Solution)
+```
+2/ Problem: MCP servers often have unclear tool descriptions, poor parameter naming, and missing context - making them hard for AI agents to use effectively.
+
+Solution: MCP Doctor analyzes your servers in seconds and provides actionable recommendations for improvement.
+```
+
+### Tweet 3 (Key Features)
+```
+3/ Key features:
+⚡ Rule-based analysis (sub-second results)
+🔍 Deep diagnostic capabilities
+📊 Multiple output formats (table, JSON, YAML)
+🛡️ Smart credential filtering
+🚀 Easy CLI and Python API
+
+Perfect for rapid iteration during development!
+```
+
+### Tweet 4 (Demo)
+```
+4/ See it in action! 
+
+[Attach demo video/GIF]
+
+MCP Doctor quickly identifies issues like:
+• Unclear tool purposes
+• Technical jargon in descriptions  
+• Missing parameter context
+• Poor naming patterns
+
+GitHub: https://github.com/destilabs/mcp-doctor
+```
+
+### Tweet 5 (Call to Action)
+```
+5/ 🙏 If you're working with MCP servers or AI agents, give it a try!
+
+⭐ Star the repo if you find it useful
+🐛 Report issues or suggest features
+🤝 Contributions welcome!
+
+Built with ❤️ for the AI developer community
+
+#AITools #MachineLearning #Anthropic
+```
+
+## 📱 LinkedIn Post
+
+### Professional Announcement
+```
+🩺 Launching MCP Doctor: Open Source Diagnostic Tool for AI Agent Integration
+
+I'm excited to share MCP Doctor, a comprehensive diagnostic tool I've built for developers working with Model Context Protocol (MCP) servers.
+
+🎯 THE PROBLEM
+As AI agents become more sophisticated, ensuring MCP servers are "agent-friendly" has become critical. Poor tool descriptions, unclear parameters, and missing context can break agent workflows.
+
+⚡ THE SOLUTION
+MCP Doctor performs lightning-fast analysis of MCP servers (both HTTP and NPX-launched) and provides actionable recommendations. No AI dependencies means consistent, sub-second results - perfect for rapid development iteration.
+
+🔑 KEY FEATURES
+• Rule-based analysis for speed and consistency
+• Security-first design with smart credential filtering
+• Support for multiple server types and output formats
+• Comprehensive diagnostic capabilities
+• Easy CLI and Python API
+
+🚀 BUILT FOR DEVELOPERS
+Having worked extensively with AI systems, I know how frustrating it can be when tools don't work well with agents. MCP Doctor addresses real pain points I've experienced and heard from the community.
+
+The project is fully open source and follows best practices:
+✅ Comprehensive test suite
+✅ CI/CD pipeline
+✅ Security scanning
+✅ Type checking
+✅ Detailed documentation
+
+🤝 COMMUNITY
+If you're working with MCP servers, AI agents, or developer tools, I'd love your feedback! The project is designed to grow with community input.
+
+GitHub: https://github.com/destilabs/mcp-doctor
+
+#AI #OpenSource #DeveloperTools #Python #MachineLearning #Anthropic
+```
+
+## 📝 Reddit Post Templates
+
+### r/MachineLearning
+```
+Title: [P] MCP Doctor: Open Source Diagnostic Tool for Model Context Protocol Servers
+
+I've built and open-sourced MCP Doctor, a diagnostic tool for developers working with Model Context Protocol (MCP) servers and AI agents.
+
+**The Problem:**
+MCP servers often have unclear tool descriptions, poor parameter naming, and missing context, making them difficult for AI agents to use effectively. This leads to failed agent interactions and debugging headaches.
+
+**The Solution:**
+MCP Doctor performs comprehensive analysis of MCP servers and provides actionable recommendations. It's designed for speed (rule-based, not AI-powered) to support rapid development iteration.
+
+**Key Features:**
+- Lightning-fast analysis (sub-second results)
+- Security-first with automatic credential filtering
+- Support for HTTP and NPX-launched servers
+- Multiple output formats (table, JSON, YAML)
+- Python API for programmatic use
+
+**Technical Details:**
+- Built with async Python for performance
+- Comprehensive test suite with CI/CD
+- Type-checked with mypy
+- Follows Anthropic's MCP best practices
+
+**Demo Videos:**
+[Links to your demo videos]
+
+**GitHub:** https://github.com/destilabs/mcp-doctor
+
+I'd love feedback from the ML community, especially those working with AI agents or MCP servers!
+```
+
+### r/Python
+```
+Title: [Project] MCP Doctor - CLI tool for diagnosing Model Context Protocol servers
+
+Built a Python CLI tool called MCP Doctor for analyzing MCP (Model Context Protocol) servers. It helps ensure servers work well with AI agents by checking tool descriptions, parameter schemas, and following best practices.
+
+**Tech Stack:**
+- Python 3.10+ with async/await
+- Typer for CLI
+- httpx for HTTP clients
+- Rich for beautiful terminal output
+- Comprehensive pytest suite
+
+**Features:**
+- Rule-based analysis (fast, consistent results)
+- Support for HTTP and subprocess-launched servers
+- Security-focused with credential filtering
+- Multiple output formats
+- Type hints throughout
+
+**Architecture Highlights:**
+- Clean separation between checkers, clients, and reports
+- Async-first design for performance
+- Extensible checker system for new diagnostics
+- Proper error handling and logging
+
+The codebase follows Python best practices with black formatting, isort imports, and mypy type checking. CI/CD pipeline ensures code quality.
+
+**GitHub:** https://github.com/destilabs/mcp-doctor
+
+Would appreciate feedback on the code structure and any suggestions for improvements!
+```
+
+## 📧 Email Templates
+
+### Newsletter Pitch
+```
+Subject: New Open Source Tool: MCP Doctor for AI Agent Development
+
+Hi [Editor],
+
+I wanted to share MCP Doctor, a new open source diagnostic tool that addresses growing needs in AI agent development.
+
+**What it does:** Analyzes Model Context Protocol servers to ensure they work well with AI agents, providing actionable recommendations for improvement.
+
+**Why it matters:** As AI agents become more prevalent, ensuring proper integration between agents and tools is critical. MCP Doctor solves real pain points developers face.
+
+**What makes it interesting:**
+- Takes a unique "speed-first" approach (rule-based vs AI-powered)
+- Security-first design with credential protection
+- Growing relevance as MCP ecosystem expands
+- Built by someone with hands-on AI development experience
+
+**Community traction:** [Update with actual metrics when available]
+
+I'd be happy to provide more details, arrange a demo, or answer any questions if this fits your coverage area.
+
+Best regards,
+[Your name]
+```
+
+## 🎥 Video Script Ideas
+
+### 30-Second Demo
+```
+"Meet MCP Doctor - the diagnostic tool for AI agent integration.
+
+[Show terminal] Run one command...
+[Show analysis results] Get instant feedback on your MCP server.
+[Highlight issues] See exactly what needs fixing.
+[Show improvements] Watch your agent compatibility improve.
+
+Lightning fast. Security focused. Open source.
+
+Try MCP Doctor today!"
+```
+
+### 2-Minute Technical Overview
+```
+"If you're building AI agents that interact with external tools, you've probably run into this problem...
+
+[Show failed agent interaction]
+
+Your MCP server works, but agents can't use it effectively. The descriptions are unclear, parameters are confusing, and there's missing context.
+
+That's why I built MCP Doctor.
+
+[Show tool in action]
+
+MCP Doctor analyzes your server in seconds and tells you exactly what needs fixing. Unlike other tools, it uses rule-based analysis for consistent, fast results.
+
+[Show before/after comparison]
+
+Here's the same server before and after applying MCP Doctor's recommendations. See the difference?
+
+The tool is completely open source and designed for daily use. Try it on your next MCP server!"
+```
+
+## 📊 Metrics to Track
+
+### GitHub Metrics
+- Stars, forks, watchers
+- Issues opened/closed
+- Pull requests
+- Contributors
+- Clone/download stats
+
+### Social Media Metrics
+- Likes, shares, comments
+- Click-through rates
+- Follower growth
+- Mention tracking
+
+### Community Metrics
+- Reddit upvotes/comments
+- Hacker News points/comments
+- Blog post views
+- Video views/engagement
+
+Remember to customize these templates with your personal voice and add specific metrics as they become available!
+```

--- a/src/mcp_analyzer/cli.py
+++ b/src/mcp_analyzer/cli.py
@@ -188,7 +188,6 @@ async def _run_analysis(
     return results
 
 
-
 @app.command()
 def generate_dataset(
     target: Optional[str] = typer.Option(
@@ -206,7 +205,9 @@ def generate_dataset(
         None,
         help="Override default model name for the chosen provider",
     ),
-    timeout: int = typer.Option(30, help="Request timeout in seconds when fetching tools"),
+    timeout: int = typer.Option(
+        30, help="Request timeout in seconds when fetching tools"
+    ),
     env_vars: Optional[str] = typer.Option(
         None,
         "--env-vars",

--- a/src/mcp_analyzer/cli.py
+++ b/src/mcp_analyzer/cli.py
@@ -1,16 +1,20 @@
 """Main CLI interface for MCP Analyzer."""
 
 import asyncio
+import json
 from enum import Enum
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 import typer
 from rich.console import Console
 
 from .checkers import DescriptionChecker, TokenEfficiencyChecker
+from .dataset_generator import DatasetGenerationError, DatasetGenerator
 from .mcp_client import MCPClient
 from .npx_launcher import is_npx_command
 from .reports import ReportFormatter
+from .tool_utils import fetch_tools_for_dataset, load_tools_from_file
 
 console = Console()
 app = typer.Typer(
@@ -182,6 +186,91 @@ async def _run_analysis(
         await client.close()
 
     return results
+
+
+
+@app.command()
+def generate_dataset(
+    target: Optional[str] = typer.Option(
+        None,
+        help="MCP server URL or NPX command to pull tool metadata from",
+    ),
+    tools_file: Optional[Path] = typer.Option(
+        None,
+        help="Path to JSON file describing MCP tools (alternative to --target)",
+    ),
+    num_tasks: int = typer.Option(
+        5, min=1, max=20, help="Number of synthetic tasks to generate"
+    ),
+    model: Optional[str] = typer.Option(
+        None,
+        help="Override default model name for the chosen provider",
+    ),
+    timeout: int = typer.Option(30, help="Request timeout in seconds when fetching tools"),
+    env_vars: Optional[str] = typer.Option(
+        None,
+        "--env-vars",
+        help='Environment variables for NPX command (JSON format: \'{"API_KEY": "value"}\')',
+    ),
+    working_dir: Optional[str] = typer.Option(
+        None, "--working-dir", help="Working directory for NPX command"
+    ),
+    no_env_logging: bool = typer.Option(
+        False,
+        "--no-env-logging",
+        help="Disable environment variable logging for security",
+    ),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        help="Path to save generated dataset as JSON; prints to stdout when omitted",
+    ),
+    llm_timeout: float = typer.Option(
+        60.0,
+        "--llm-timeout",
+        help="Timeout (seconds) for LLM responses when generating datasets",
+    ),
+) -> None:
+    """Generate synthetic datasets for MCP tool use cases."""
+
+    if bool(target) == bool(tools_file):
+        console.print(
+            "[red]❌ Provide exactly one of --target or --tools-file to choose tool sources[/red]"
+        )
+        raise typer.Exit(1)
+
+    try:
+        if target:
+            npx_kwargs: Dict[str, Any] = {}
+            if env_vars:
+                try:
+                    npx_kwargs["env_vars"] = json.loads(env_vars)
+                except json.JSONDecodeError as exc:
+                    raise DatasetGenerationError(f"Invalid JSON in env-vars: {exc}")
+
+            if working_dir:
+                npx_kwargs["working_dir"] = working_dir
+
+            if no_env_logging:
+                npx_kwargs["log_env_vars"] = False
+
+            tools = asyncio.run(fetch_tools_for_dataset(target, timeout, npx_kwargs))
+        else:
+            assert tools_file is not None  # narrow type for mypy
+            tools = load_tools_from_file(tools_file)
+
+        generator = DatasetGenerator(model=model, llm_timeout=llm_timeout)
+        dataset = asyncio.run(generator.generate_dataset(tools, num_tasks=num_tasks))
+
+        if output:
+            output.write_text(json.dumps(dataset, indent=2), encoding="utf-8")
+            console.print(f"✅ Dataset saved to [cyan]{output}[/cyan]")
+        else:
+            console.print_json(data=dataset)
+
+    except DatasetGenerationError as exc:
+        console.print(f"[red]❌ {exc}[/red]")
+        raise typer.Exit(1)
 
 
 @app.command()

--- a/src/mcp_analyzer/dataset_generator.py
+++ b/src/mcp_analyzer/dataset_generator.py
@@ -105,7 +105,9 @@ class AnthropicClient:
             ],
         }
 
-        async with httpx.AsyncClient(timeout=self.timeout, base_url=self.base_url) as client:
+        async with httpx.AsyncClient(
+            timeout=self.timeout, base_url=self.base_url
+        ) as client:
             response = await client.post("/v1/messages", headers=headers, json=payload)
             try:
                 response.raise_for_status()
@@ -119,7 +121,9 @@ class AnthropicClient:
         try:
             content_blocks = data["content"]
         except (KeyError, TypeError) as exc:
-            raise DatasetGenerationError("Unexpected response format from Anthropic API") from exc
+            raise DatasetGenerationError(
+                "Unexpected response format from Anthropic API"
+            ) from exc
 
         text_parts = [
             block.get("text", "")
@@ -127,7 +131,9 @@ class AnthropicClient:
             if isinstance(block, dict) and block.get("type") == "text"
         ]
         if not text_parts:
-            raise DatasetGenerationError("Anthropic response did not contain text content")
+            raise DatasetGenerationError(
+                "Anthropic response did not contain text content"
+            )
         return "\n".join(part.strip() for part in text_parts if part).strip()
 
 
@@ -170,7 +176,9 @@ class OpenAIClient:
         if isinstance(output_text, str) and output_text.strip():
             return output_text.strip()
         if isinstance(output_text, list):
-            joined = "\n".join(part.strip() for part in output_text if isinstance(part, str))
+            joined = "\n".join(
+                part.strip() for part in output_text if isinstance(part, str)
+            )
             if joined.strip():
                 return joined.strip()
 
@@ -184,7 +192,9 @@ class OpenAIClient:
                     if isinstance(content, str):
                         return content.strip()
 
-        raise DatasetGenerationError("OpenAI response did not include usable text content")
+        raise DatasetGenerationError(
+            "OpenAI response did not include usable text content"
+        )
 
     async def complete(self, prompt: str) -> str:
         headers = {
@@ -197,7 +207,9 @@ class OpenAIClient:
             "max_output_tokens": self.max_tokens,
         }
 
-        async with httpx.AsyncClient(timeout=self.timeout, base_url=self.base_url) as client:
+        async with httpx.AsyncClient(
+            timeout=self.timeout, base_url=self.base_url
+        ) as client:
             response = await client.post("/v1/responses", headers=headers, json=payload)
             try:
                 response.raise_for_status()
@@ -277,7 +289,7 @@ class DatasetGenerator:
         tool_block = "\n\n".join(tool_sections)
         instructions = (
             "You are helping generate synthetic training data for MCP tool usage. "
-            "Create a JSON array with exactly {num_tasks} task objects. Each object must contain:"\
+            "Create a JSON array with exactly {num_tasks} task objects. Each object must contain:"
             "\n  - 'prompt': Natural language instructions for an analyst or developer.\n"
             "  - 'tools_called': Array of tool names used in execution order.\n"
             "  - 'tools_args': Array of arrays representing arguments passed to each tool.\n"
@@ -297,10 +309,14 @@ class DatasetGenerator:
         try:
             parsed = json.loads(json_text)
         except json.JSONDecodeError as exc:
-            raise DatasetGenerationError("Failed to parse LLM response as JSON") from exc
+            raise DatasetGenerationError(
+                "Failed to parse LLM response as JSON"
+            ) from exc
 
         if not isinstance(parsed, list):
-            raise DatasetGenerationError("Expected response to be a JSON array of tasks")
+            raise DatasetGenerationError(
+                "Expected response to be a JSON array of tasks"
+            )
         return parsed
 
     def _extract_json(self, text: str) -> str:
@@ -310,7 +326,9 @@ class DatasetGenerator:
             return match.group(1).strip()
         return text.strip()
 
-    def _validate_dataset(self, dataset: Iterable[Dict[str, Any]], tools: Sequence[MCPTool]) -> None:
+    def _validate_dataset(
+        self, dataset: Iterable[Dict[str, Any]], tools: Sequence[MCPTool]
+    ) -> None:
         tool_names = {tool.name for tool in tools}
         for index, item in enumerate(dataset):
             if not isinstance(item, dict):

--- a/src/mcp_analyzer/dataset_generator.py
+++ b/src/mcp_analyzer/dataset_generator.py
@@ -1,0 +1,358 @@
+"""Synthetic dataset generation using LLM providers."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence
+
+import httpx
+
+from .mcp_client import MCPTool
+
+
+class DatasetGenerationError(Exception):
+    """Raised when synthetic dataset generation fails."""
+
+
+class ProviderResolutionError(DatasetGenerationError):
+    """Raised when a model provider cannot be determined."""
+
+
+class ModelProvider(str, Enum):
+    """Supported LLM providers for dataset generation."""
+
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+
+
+DEFAULT_MODELS: Dict[ModelProvider, str] = {
+    ModelProvider.ANTHROPIC: "claude-4-sonnet",
+    ModelProvider.OPENAI: "gpt-4.1",
+}
+
+
+@dataclass
+class ProviderConfig:
+    """Resolved provider configuration."""
+
+    provider: ModelProvider
+    api_key: str
+    model: str
+
+
+class LLMClient(Protocol):
+    """Protocol for language model clients."""
+
+    async def complete(self, prompt: str) -> str:
+        """Return raw text completion for the given prompt."""
+
+
+def resolve_provider(model: Optional[str] = None) -> ProviderConfig:
+    """Resolve which provider to use based on environment variables."""
+
+    anthropic_key = os.getenv("ANTHROPIC_API_KEY")
+    openai_key = os.getenv("OPENAI_API_KEY")
+
+    if anthropic_key:
+        resolved_model = model or DEFAULT_MODELS[ModelProvider.ANTHROPIC]
+        return ProviderConfig(ModelProvider.ANTHROPIC, anthropic_key, resolved_model)
+
+    if openai_key:
+        resolved_model = model or DEFAULT_MODELS[ModelProvider.OPENAI]
+        return ProviderConfig(ModelProvider.OPENAI, openai_key, resolved_model)
+
+    raise ProviderResolutionError(
+        "Set either ANTHROPIC_API_KEY or OPENAI_API_KEY to generate datasets."
+    )
+
+
+class AnthropicClient:
+    """Minimal Anthropic Messages API client."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str,
+        *,
+        timeout: float = 60.0,
+        max_tokens: int = 2048,
+    ) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.timeout = timeout
+        self.max_tokens = max_tokens
+        self.base_url = os.getenv("ANTHROPIC_API_BASE", "https://api.anthropic.com")
+        self.api_version = os.getenv("ANTHROPIC_API_VERSION", "2023-06-01")
+
+    async def complete(self, prompt: str) -> str:
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": self.api_version,
+            "content-type": "application/json",
+        }
+        payload = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": prompt,
+                }
+            ],
+        }
+
+        async with httpx.AsyncClient(timeout=self.timeout, base_url=self.base_url) as client:
+            response = await client.post("/v1/messages", headers=headers, json=payload)
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:  # pragma: no cover - thin wrapper
+                raise DatasetGenerationError(
+                    f"Anthropic API request failed with status {exc.response.status_code}"
+                ) from exc
+
+        data = response.json()
+
+        try:
+            content_blocks = data["content"]
+        except (KeyError, TypeError) as exc:
+            raise DatasetGenerationError("Unexpected response format from Anthropic API") from exc
+
+        text_parts = [
+            block.get("text", "")
+            for block in content_blocks
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        if not text_parts:
+            raise DatasetGenerationError("Anthropic response did not contain text content")
+        return "\n".join(part.strip() for part in text_parts if part).strip()
+
+
+class OpenAIClient:
+    """Minimal OpenAI Responses API client."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str,
+        *,
+        timeout: float = 60.0,
+        max_tokens: int = 2048,
+    ) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.timeout = timeout
+        self.max_tokens = max_tokens
+        self.base_url = os.getenv("OPENAI_API_BASE", "https://api.openai.com")
+
+    @staticmethod
+    def _extract_text(data: Dict[str, Any]) -> str:
+        output_entries = data.get("output")
+        if isinstance(output_entries, list):
+            text_parts: List[str] = []
+            for entry in output_entries:
+                if not isinstance(entry, dict):
+                    continue
+                for content in entry.get("content", []):
+                    if (
+                        isinstance(content, dict)
+                        and content.get("type") in {"text", "output_text"}
+                        and isinstance(content.get("text"), str)
+                    ):
+                        text_parts.append(content["text"].strip())
+            if text_parts:
+                return "\n".join(text_parts).strip()
+
+        output_text = data.get("output_text")
+        if isinstance(output_text, str) and output_text.strip():
+            return output_text.strip()
+        if isinstance(output_text, list):
+            joined = "\n".join(part.strip() for part in output_text if isinstance(part, str))
+            if joined.strip():
+                return joined.strip()
+
+        choices = data.get("choices")
+        if isinstance(choices, list) and choices:
+            first_choice = choices[0]
+            if isinstance(first_choice, dict):
+                message = first_choice.get("message")
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if isinstance(content, str):
+                        return content.strip()
+
+        raise DatasetGenerationError("OpenAI response did not include usable text content")
+
+    async def complete(self, prompt: str) -> str:
+        headers = {
+            "authorization": f"Bearer {self.api_key}",
+            "content-type": "application/json",
+        }
+        payload = {
+            "model": self.model,
+            "input": prompt,
+            "max_output_tokens": self.max_tokens,
+        }
+
+        async with httpx.AsyncClient(timeout=self.timeout, base_url=self.base_url) as client:
+            response = await client.post("/v1/responses", headers=headers, json=payload)
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:  # pragma: no cover - thin wrapper
+                raise DatasetGenerationError(
+                    f"OpenAI API request failed with status {exc.response.status_code}"
+                ) from exc
+
+        data = response.json()
+        return self._extract_text(data)
+
+
+class DatasetGenerator:
+    """Generate synthetic datasets of tool use cases."""
+
+    def __init__(
+        self,
+        *,
+        llm_client: Optional[LLMClient] = None,
+        model: Optional[str] = None,
+        max_tasks: int = 20,
+        llm_timeout: float = 60.0,
+    ) -> None:
+        self.max_tasks = max_tasks
+        self.llm_timeout = llm_timeout
+        if llm_client is not None:
+            self._llm_client = llm_client
+        else:
+            provider = resolve_provider(model=model)
+            if provider.provider == ModelProvider.ANTHROPIC:
+                self._llm_client = AnthropicClient(
+                    provider.api_key, provider.model, timeout=self.llm_timeout
+                )
+            else:
+                self._llm_client = OpenAIClient(
+                    provider.api_key, provider.model, timeout=self.llm_timeout
+                )
+
+    async def generate_dataset(
+        self, tools: Sequence[MCPTool], *, num_tasks: int = 5
+    ) -> List[Dict[str, Any]]:
+        """Generate synthetic dataset entries for the provided tools."""
+        if not tools:
+            raise DatasetGenerationError("Provide at least one tool to generate tasks")
+
+        if num_tasks < 1:
+            raise DatasetGenerationError("Number of tasks must be greater than zero")
+
+        if num_tasks > self.max_tasks:
+            raise DatasetGenerationError(
+                f"Requested {num_tasks} tasks but the generator allows up to {self.max_tasks}"
+            )
+
+        prompt = self._build_prompt(tools, num_tasks)
+        raw_response = await self._llm_client.complete(prompt)
+        dataset = self._parse_dataset(raw_response)
+        self._validate_dataset(dataset, tools)
+        return dataset
+
+    def _build_prompt(self, tools: Sequence[MCPTool], num_tasks: int) -> str:
+        tool_sections = []
+        for tool in tools:
+            description = tool.description or "No description provided"
+            parameters = tool.parameters or tool.input_schema or {}
+            tool_sections.append(
+                json.dumps(
+                    {
+                        "name": tool.name,
+                        "description": description,
+                        "parameters": parameters,
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+
+        tool_block = "\n\n".join(tool_sections)
+        instructions = (
+            "You are helping generate synthetic training data for MCP tool usage. "
+            "Create a JSON array with exactly {num_tasks} task objects. Each object must contain:"\
+            "\n  - 'prompt': Natural language instructions for an analyst or developer.\n"
+            "  - 'tools_called': Array of tool names used in execution order.\n"
+            "  - 'tools_args': Array of arrays representing arguments passed to each tool.\n"
+            "Ensure 'tools_args' has the same length and order as 'tools_called'. "
+            "Focus on realistic workflows combining tools when appropriate. "
+            "Only return valid JSON, without commentary or markdown fences."
+        ).format(num_tasks=num_tasks)
+
+        return (
+            f"Available MCP tools (JSON format):\n{tool_block}\n\n"
+            f"{instructions}\n"
+            "Use concise prompts (max 40 words). Include both single-tool and multi-tool use cases."
+        )
+
+    def _parse_dataset(self, response_text: str) -> List[Dict[str, Any]]:
+        json_text = self._extract_json(response_text)
+        try:
+            parsed = json.loads(json_text)
+        except json.JSONDecodeError as exc:
+            raise DatasetGenerationError("Failed to parse LLM response as JSON") from exc
+
+        if not isinstance(parsed, list):
+            raise DatasetGenerationError("Expected response to be a JSON array of tasks")
+        return parsed
+
+    def _extract_json(self, text: str) -> str:
+        code_block_pattern = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+        match = code_block_pattern.search(text)
+        if match:
+            return match.group(1).strip()
+        return text.strip()
+
+    def _validate_dataset(self, dataset: Iterable[Dict[str, Any]], tools: Sequence[MCPTool]) -> None:
+        tool_names = {tool.name for tool in tools}
+        for index, item in enumerate(dataset):
+            if not isinstance(item, dict):
+                raise DatasetGenerationError(
+                    f"Task at index {index} is not an object: {type(item).__name__}"
+                )
+
+            prompt = item.get("prompt")
+            if not isinstance(prompt, str) or not prompt.strip():
+                raise DatasetGenerationError(
+                    f"Task {index} is missing a valid 'prompt' string"
+                )
+
+            tools_called = item.get("tools_called")
+            if not isinstance(tools_called, list) or not tools_called:
+                raise DatasetGenerationError(
+                    f"Task {index} must include a non-empty 'tools_called' list"
+                )
+
+            tools_args = item.get("tools_args")
+            if not isinstance(tools_args, list) or len(tools_args) != len(tools_called):
+                raise DatasetGenerationError(
+                    f"Task {index} 'tools_args' must align with 'tools_called'"
+                )
+
+            for tool_name in tools_called:
+                if tool_name not in tool_names:
+                    raise DatasetGenerationError(
+                        f"Task {index} references unknown tool '{tool_name}'"
+                    )
+
+            for arg_index, arg_set in enumerate(tools_args):
+                if not isinstance(arg_set, list):
+                    raise DatasetGenerationError(
+                        f"Task {index} argument entry {arg_index} is not a list"
+                    )
+
+
+__all__ = [
+    "DatasetGenerator",
+    "DatasetGenerationError",
+    "ProviderResolutionError",
+    "resolve_provider",
+    "ModelProvider",
+]

--- a/src/mcp_analyzer/tool_utils.py
+++ b/src/mcp_analyzer/tool_utils.py
@@ -1,0 +1,92 @@
+"""Utilities for loading and fetching MCP tools."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pydantic import ValidationError
+from rich.console import Console
+
+from .dataset_generator import DatasetGenerationError
+from .mcp_client import MCPClient, MCPTool
+from .npx_launcher import is_npx_command
+
+console = Console()
+
+
+def load_tools_from_file(tools_file: Path) -> List[MCPTool]:
+    """Load MCP tools from a JSON file."""
+
+    if not tools_file.exists():
+        raise DatasetGenerationError(f"Tools file not found: {tools_file}")
+
+    content = tools_file.read_text(encoding="utf-8").strip()
+    if not content:
+        raise DatasetGenerationError("Tools file is empty")
+
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise DatasetGenerationError("Tools file must contain valid JSON") from exc
+
+    if not isinstance(payload, list):
+        raise DatasetGenerationError("Tools file must contain a JSON array")
+
+    tools: List[MCPTool] = []
+    for index, entry in enumerate(payload):
+        if isinstance(entry, str):
+            tools.append(MCPTool(name=entry))
+            continue
+        if isinstance(entry, dict):
+            try:
+                tools.append(MCPTool(**entry))
+            except ValidationError as exc:
+                raise DatasetGenerationError(
+                    f"Invalid tool definition at index {index}: {exc}"
+                ) from exc
+            continue
+        raise DatasetGenerationError(
+            f"Unsupported tool entry at index {index}: {type(entry).__name__}"
+        )
+
+    if not tools:
+        raise DatasetGenerationError("Tools file must define at least one tool")
+
+    return tools
+
+
+async def fetch_tools_for_dataset(
+    target: str, timeout: int, npx_kwargs: Optional[Dict[str, Any]] = None
+) -> List[MCPTool]:
+    """Fetch MCP tools from a running server or NPX command."""
+
+    if npx_kwargs is None:
+        npx_kwargs = {}
+
+    client = MCPClient(target, timeout=timeout, **npx_kwargs)
+    is_npx = is_npx_command(target)
+
+    status_message = (
+        "[bold green]Launching NPX server..." if is_npx else "[bold green]Connecting to MCP server..."
+    )
+
+    with console.status(status_message):
+        server_info = await client.get_server_info()
+        tools = await client.get_tools()
+
+    try:
+        if is_npx:
+            actual_url = client.get_server_url()
+            console.print(f"✅ NPX server launched at [cyan]{actual_url}[/cyan]")
+        else:
+            console.print(f"✅ Connected to MCP server [cyan]{target}[/cyan]")
+
+        server_name = getattr(server_info, "server_name", None)
+        if server_name:
+            console.print(f"📛 Server name: [bold]{server_name}[/bold]")
+
+        console.print(f"📦 Retrieved [bold]{len(tools)}[/bold] tools\n")
+    finally:
+        await client.close()
+
+    return tools

--- a/src/mcp_analyzer/tool_utils.py
+++ b/src/mcp_analyzer/tool_utils.py
@@ -67,7 +67,9 @@ async def fetch_tools_for_dataset(
     is_npx = is_npx_command(target)
 
     status_message = (
-        "[bold green]Launching NPX server..." if is_npx else "[bold green]Connecting to MCP server..."
+        "[bold green]Launching NPX server..."
+        if is_npx
+        else "[bold green]Connecting to MCP server..."
     )
 
     with console.status(status_message):

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -6,15 +6,15 @@ from pathlib import Path
 import pytest
 
 import mcp_analyzer.dataset_generator as dataset_module
-from mcp_analyzer.cli import _load_tools_from_file
 from mcp_analyzer.dataset_generator import (
-    DatasetGenerator,
     DatasetGenerationError,
+    DatasetGenerator,
     ModelProvider,
     OpenAIClient,
     resolve_provider,
 )
 from mcp_analyzer.mcp_client import MCPTool
+from mcp_analyzer.tool_utils import load_tools_from_file
 
 
 class DummyClient:
@@ -64,7 +64,9 @@ async def test_dataset_generator_success(sample_tools: list[MCPTool]) -> None:
 
 
 @pytest.mark.asyncio
-async def test_dataset_generator_detects_invalid_tools(sample_tools: list[MCPTool]) -> None:
+async def test_dataset_generator_detects_invalid_tools(
+    sample_tools: list[MCPTool],
+) -> None:
     """Generator should raise when dataset references unknown tools."""
 
     response = json.dumps(
@@ -209,7 +211,9 @@ async def test_dataset_generator_allows_custom_timeout(
         api_key = "key"
         model = "gpt"
 
-    monkeypatch.setattr(dataset_module, "resolve_provider", lambda model=None: FakeProvider)
+    monkeypatch.setattr(
+        dataset_module, "resolve_provider", lambda model=None: FakeProvider
+    )
 
     captured: dict[str, float] = {}
 
@@ -250,7 +254,7 @@ def test_load_tools_from_file(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    tools = _load_tools_from_file(tools_path)
+    tools = load_tools_from_file(tools_path)
 
     assert len(tools) == 2
     assert tools[0].name == "calculate"
@@ -264,4 +268,4 @@ def test_load_tools_from_file_invalid(tmp_path: Path) -> None:
     tools_path.write_text(json.dumps([123]), encoding="utf-8")
 
     with pytest.raises(DatasetGenerationError):
-        _load_tools_from_file(tools_path)
+        load_tools_from_file(tools_path)

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -1,0 +1,267 @@
+"""Tests for synthetic dataset generation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import mcp_analyzer.dataset_generator as dataset_module
+from mcp_analyzer.cli import _load_tools_from_file
+from mcp_analyzer.dataset_generator import (
+    DatasetGenerator,
+    DatasetGenerationError,
+    ModelProvider,
+    OpenAIClient,
+    resolve_provider,
+)
+from mcp_analyzer.mcp_client import MCPTool
+
+
+class DummyClient:
+    """Fake LLM client for tests."""
+
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.last_prompt: str | None = None
+
+    async def complete(self, prompt: str) -> str:
+        self.last_prompt = prompt
+        return self.response
+
+
+@pytest.fixture
+def sample_tools() -> list[MCPTool]:
+    """Return a small set of tools for testing."""
+
+    return [
+        MCPTool(name="calculate", description="Add two numbers"),
+        MCPTool(name="print", description="Print value"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dataset_generator_success(sample_tools: list[MCPTool]) -> None:
+    """Dataset generator should parse valid JSON output."""
+
+    response = json.dumps(
+        [
+            {
+                "prompt": "Add 2 and 2 then print the result",
+                "tools_called": ["calculate", "print"],
+                "tools_args": [["2", "2"], ["4"]],
+            }
+        ],
+        indent=2,
+    )
+    client = DummyClient(f"```json\n{response}\n```")
+    generator = DatasetGenerator(llm_client=client)
+
+    dataset = await generator.generate_dataset(sample_tools, num_tasks=1)
+
+    assert dataset[0]["tools_called"] == ["calculate", "print"]
+    assert dataset[0]["tools_args"][0] == ["2", "2"]
+    assert "calculate" in client.last_prompt
+
+
+@pytest.mark.asyncio
+async def test_dataset_generator_detects_invalid_tools(sample_tools: list[MCPTool]) -> None:
+    """Generator should raise when dataset references unknown tools."""
+
+    response = json.dumps(
+        [
+            {
+                "prompt": "Call unsupported tool",
+                "tools_called": ["missing"],
+                "tools_args": [["1"]],
+            }
+        ]
+    )
+    generator = DatasetGenerator(llm_client=DummyClient(response))
+
+    with pytest.raises(DatasetGenerationError):
+        await generator.generate_dataset(sample_tools, num_tasks=1)
+
+
+@pytest.mark.asyncio
+async def test_dataset_generator_max_tasks_guard(sample_tools: list[MCPTool]) -> None:
+    """Generator should guard against excessive task counts."""
+
+    generator = DatasetGenerator(llm_client=DummyClient("[]"), max_tasks=2)
+    with pytest.raises(DatasetGenerationError):
+        await generator.generate_dataset(sample_tools, num_tasks=3)
+
+
+@pytest.mark.asyncio
+async def test_dataset_generator_mismatched_args(sample_tools: list[MCPTool]) -> None:
+    """Generator should detect tools_args mismatch."""
+
+    response = json.dumps(
+        [
+            {
+                "prompt": "Add numbers",
+                "tools_called": ["calculate"],
+                "tools_args": [],
+            }
+        ]
+    )
+    generator = DatasetGenerator(llm_client=DummyClient(response))
+
+    with pytest.raises(DatasetGenerationError):
+        await generator.generate_dataset(sample_tools, num_tasks=1)
+
+
+def test_resolve_provider_prefers_anthropic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Anthropic key should take precedence when both are present."""
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+
+    config = resolve_provider()
+
+    assert config.provider == ModelProvider.ANTHROPIC
+    assert config.model == "claude-4-sonnet"
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def test_resolve_provider_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OpenAI provider should be selected when only that key is present."""
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+
+    config = resolve_provider(model="gpt-custom")
+
+    assert config.provider == ModelProvider.OPENAI
+    assert config.model == "gpt-custom"
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def test_resolve_provider_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing keys should raise an explicit error."""
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(DatasetGenerationError):
+        resolve_provider()
+
+
+def test_openai_extract_text_from_output_entries() -> None:
+    """OpenAI parser should handle output_text content entries."""
+
+    dataset_json = json.dumps(
+        [
+            {
+                "prompt": "Add numbers",
+                "tools_called": ["calculate"],
+                "tools_args": [["1", "2"]],
+            }
+        ]
+    )
+    payload = {
+        "output": [
+            {
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": dataset_json,
+                    }
+                ]
+            }
+        ]
+    }
+
+    extracted = OpenAIClient._extract_text(payload)
+
+    assert json.loads(extracted)[0]["tools_called"] == ["calculate"]
+
+
+def test_openai_extract_text_from_output_text_list() -> None:
+    """OpenAI parser should support output_text helper field."""
+
+    dataset_json = json.dumps(
+        [
+            {
+                "prompt": "Print sum",
+                "tools_called": ["print"],
+                "tools_args": [["42"]],
+            }
+        ]
+    )
+    payload = {"output_text": [dataset_json]}
+
+    extracted = OpenAIClient._extract_text(payload)
+
+    assert json.loads(extracted)[0]["tools_args"][0] == ["42"]
+
+
+@pytest.mark.asyncio
+async def test_dataset_generator_allows_custom_timeout(
+    monkeypatch: pytest.MonkeyPatch, sample_tools: list[MCPTool]
+) -> None:
+    """Custom timeout should be forwarded to the provider client."""
+
+    class FakeProvider:
+        provider = ModelProvider.OPENAI
+        api_key = "key"
+        model = "gpt"
+
+    monkeypatch.setattr(dataset_module, "resolve_provider", lambda model=None: FakeProvider)
+
+    captured: dict[str, float] = {}
+
+    class FakeLLM:
+        async def complete(self, prompt: str) -> str:
+            return json.dumps(
+                [
+                    {
+                        "prompt": "test",
+                        "tools_called": [sample_tools[0].name],
+                        "tools_args": [["1", "2"]],
+                    }
+                ]
+            )
+
+    def fake_openai_client(
+        api_key: str, model: str, *, timeout: float, max_tokens: int = 2048
+    ) -> FakeLLM:
+        captured["timeout"] = timeout
+        captured["max_tokens"] = max_tokens
+        return FakeLLM()
+
+    monkeypatch.setattr(dataset_module, "OpenAIClient", fake_openai_client)
+
+    generator = DatasetGenerator(llm_timeout=123.0)
+    await generator.generate_dataset(sample_tools[:1], num_tasks=1)
+
+    assert captured["timeout"] == 123.0
+    assert captured["max_tokens"] == 2048
+
+
+def test_load_tools_from_file(tmp_path: Path) -> None:
+    """Tools loader should parse strings and objects."""
+
+    tools_path = tmp_path / "tools.json"
+    tools_path.write_text(
+        json.dumps(["calculate", {"name": "print", "description": "Print value"}]),
+        encoding="utf-8",
+    )
+
+    tools = _load_tools_from_file(tools_path)
+
+    assert len(tools) == 2
+    assert tools[0].name == "calculate"
+    assert tools[1].description == "Print value"
+
+
+def test_load_tools_from_file_invalid(tmp_path: Path) -> None:
+    """Invalid definitions should raise a descriptive error."""
+
+    tools_path = tmp_path / "tools.json"
+    tools_path.write_text(json.dumps([123]), encoding="utf-8")
+
+    with pytest.raises(DatasetGenerationError):
+        _load_tools_from_file(tools_path)


### PR DESCRIPTION
- Introduced a new command in the CLI to create synthetic datasets using Claude or GPT models.
- Updated `README.md` with usage examples for the new command.
- Implemented dataset generation logic in `dataset_generator.py`, including error handling for invalid inputs.
- Added utility functions for loading tools from JSON files and fetching tools from a server.
- Included comprehensive tests for the dataset generation functionality to ensure robustness.

## Description

Brief description of what this PR does.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements

## Testing

- [x] Tests pass locally with `pytest tests/`
- [x] Code is formatted with `black src/ tests/`
- [x] Imports are sorted with `isort src/ tests/`
- [x] Type checking with `mypy src/`
- [x] New tests added for new functionality (if applicable)

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
