### PR TITLE
Remove 30-Day Development Sprint details from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,6 @@
 [![GitHub stars](https://img.shields.io/github/stars/destilabs/mcp-doctor?style=social)](https://github.com/destilabs/mcp-doctor/stargazers)
 [![GitHub issues](https://img.shields.io/github/issues/destilabs/mcp-doctor)](https://github.com/destilabs/mcp-doctor/issues)
 
-## 🚀 **30-Day Development Sprint**
-
-I'm committing to **30 Pull Requests in 30 Days** to rapidly evolve MCP Doctor based on community feedback and real-world usage!
-
-**Progress:** 16/30 PRs completed
-```
-[████████████████              ] 53% (16/30)
-```
-**Days Remaining:** 15 | **Started:** September 17, 2025 | **Ends:** October 17, 2025
-
----
-
 MCP Doctor is your go-to diagnostic tool for analyzing MCP servers and ensuring they follow best practices for AI agent integration. Just like a medical doctor diagnoses health issues, MCP Doctor diagnoses your MCP servers to ensure they're agent-friendly, performant, and compliant with [Anthropic's best practices](https://www.anthropic.com/engineering/writing-tools-for-agents).
 
 ## 🎯 What is MCP Doctor?


### PR DESCRIPTION
Removed the 30-Day Development Sprint section from README.

## Description

Brief description of what this PR does.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements

## Testing

- [ ] Tests pass locally with `pytest tests/`
- [ ] Code is formatted with `black src/ tests/`
- [ ] Imports are sorted with `isort src/ tests/`
- [ ] Type checking with `mypy src/`
- [ ] New tests added for new functionality (if applicable)

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
