### PR TITLE
fix(token_efficiency): stop dropping enum-constrained tools as false positives

### DIFF
--- a/src/mcp_analyzer/checkers/token_efficiency.py
+++ b/src/mcp_analyzer/checkers/token_efficiency.py
@@ -28,6 +28,7 @@ class IssueType(str, Enum):
     POOR_DEFAULT_LIMITS = "poor_default_limits"
     MISSING_TRUNCATION = "missing_truncation"
     NO_RESPONSE_FORMAT_CONTROL = "no_response_format_control"
+    EXECUTION_FAILURE = "execution_failure"
 
 
 class Severity(str, Enum):
@@ -593,6 +594,35 @@ class TokenEfficiencyChecker:
         """Analyze response metrics to identify efficiency issues."""
         issues = []
 
+        # Check for systematic execution failures. Failed measurements are
+        # excluded from the token-count aggregates further down (there's no
+        # token count to aggregate), but that must not make the failures
+        # invisible — otherwise a tool that fails every scenario (e.g. its
+        # enum-constrained parameters reject the generated sample values)
+        # silently drops out of analysis instead of being reported.
+        failed_measurements = [m for m in metrics.measurements if m.error is not None]
+        if (
+            metrics.measurements
+            and len(failed_measurements) / len(metrics.measurements) >= 0.5
+        ):
+            issues.append(
+                TokenEfficiencyIssue(
+                    tool_name=metrics.tool_name,
+                    issue_type=IssueType.EXECUTION_FAILURE,
+                    severity=Severity.ERROR,
+                    message=(
+                        f"Tool failed to execute in {len(failed_measurements)}/"
+                        f"{len(metrics.measurements)} test scenarios, so token "
+                        "efficiency could not be fully measured"
+                    ),
+                    suggestion=(
+                        "Check the execution errors above — the tool may require "
+                        "specific enum values, formats, or parameter combinations "
+                        "that the analyzer's generated sample values don't satisfy"
+                    ),
+                )
+            )
+
         # Check for oversized responses
         for measurement in metrics.measurements:
             if measurement.token_count > self.max_recommended_tokens:
@@ -775,6 +805,13 @@ class TokenEfficiencyChecker:
         self, param_name: str, param_schema: Dict[str, Any]
     ) -> Any:
         """Generate a sample value for a parameter based on its schema."""
+        # Enum-constrained parameters reject any value outside the enum, so a
+        # generic type-based guess (e.g. "sample_value") fails validation and
+        # the tool call errors out before token efficiency can be measured.
+        enum_values = param_schema.get("enum")
+        if enum_values:
+            return enum_values[0]
+
         param_type = param_schema.get("type", "string")
 
         if param_type == "string":
@@ -970,6 +1007,14 @@ class TokenEfficiencyChecker:
             count = issue_counts[IssueType.NO_RESPONSE_FORMAT_CONTROL]
             recommendations.append(
                 f"Add response format control (concise/detailed) to {count} tools"
+            )
+
+        if issue_counts.get(IssueType.EXECUTION_FAILURE, 0) > 0:
+            count = issue_counts[IssueType.EXECUTION_FAILURE]
+            recommendations.append(
+                f"{count} tool(s) failed execution during testing and could not be "
+                "fully analyzed for token efficiency — review the execution errors "
+                "before trusting the efficiency results for those tools"
             )
 
         # General recommendations based on stats

--- a/tests/test_token_efficiency.py
+++ b/tests/test_token_efficiency.py
@@ -110,6 +110,23 @@ class TestTokenEfficiencyChecker:
         bool_value = self.checker._generate_sample_value("enabled", bool_schema)
         assert bool_value is True
 
+        # Enum-constrained parameter: must return one of the allowed values,
+        # not a generic type-based guess that the server would reject.
+        enum_schema = {
+            "type": "string",
+            "enum": ["No emulation", "Slow 3G", "Fast 3G", "Slow 4G", "Fast 4G"],
+        }
+        enum_value = self.checker._generate_sample_value(
+            "throttlingOption", enum_schema
+        )
+        assert enum_value == "No emulation"
+
+        # Enum takes priority even when the parameter name would otherwise
+        # match a contextual pattern (e.g. "id" -> "sample_id").
+        enum_id_schema = {"type": "string", "enum": ["primary", "secondary"]}
+        enum_id_value = self.checker._generate_sample_value("id", enum_id_schema)
+        assert enum_id_value == "primary"
+
     def test_generate_test_scenarios(self):
         """Test test scenario generation."""
         # Tool with parameters
@@ -324,6 +341,89 @@ class TestTokenEfficiencyChecker:
         assert IssueType.VERBOSE_IDENTIFIERS in issue_types
         assert IssueType.REDUNDANT_DATA in issue_types
 
+    def test_analyze_response_metrics_reports_execution_failures(self):
+        """A tool that fails most of its test scenarios must surface an
+        EXECUTION_FAILURE issue instead of silently dropping out of analysis
+        (see #14: this previously let a fully-broken tool report as if it
+        had "good token efficiency")."""
+        mock_metrics = MagicMock()
+        mock_metrics.tool_name = "flaky_tool"
+        mock_metrics.measurements = [
+            ResponseMetric(
+                scenario="minimal",
+                token_count=0,
+                response_time=0,
+                response_size_bytes=0,
+                contains_low_value_data=False,
+                has_verbose_identifiers=False,
+                error="Invalid enum value",
+            ),
+            ResponseMetric(
+                scenario="typical",
+                token_count=0,
+                response_time=0,
+                response_size_bytes=0,
+                contains_low_value_data=False,
+                has_verbose_identifiers=False,
+                error="Invalid enum value",
+            ),
+            ResponseMetric(
+                scenario="large",
+                token_count=200,
+                response_time=0.2,
+                response_size_bytes=800,
+                contains_low_value_data=False,
+                has_verbose_identifiers=False,
+            ),
+        ]
+
+        issues = self.checker._analyze_response_metrics(mock_metrics)
+
+        failure_issues = [
+            i for i in issues if i.issue_type == IssueType.EXECUTION_FAILURE
+        ]
+        assert len(failure_issues) == 1
+        assert failure_issues[0].severity == Severity.ERROR
+        assert failure_issues[0].tool_name == "flaky_tool"
+        assert "2/3" in failure_issues[0].message
+
+    def test_analyze_response_metrics_no_failure_issue_below_threshold(self):
+        """A single flaky scenario out of several shouldn't trip the
+        systematic-failure check — only report it once failures dominate."""
+        mock_metrics = MagicMock()
+        mock_metrics.tool_name = "mostly_fine_tool"
+        mock_metrics.measurements = [
+            ResponseMetric(
+                scenario="minimal",
+                token_count=100,
+                response_time=0.1,
+                response_size_bytes=400,
+                contains_low_value_data=False,
+                has_verbose_identifiers=False,
+            ),
+            ResponseMetric(
+                scenario="typical",
+                token_count=150,
+                response_time=0.1,
+                response_size_bytes=600,
+                contains_low_value_data=False,
+                has_verbose_identifiers=False,
+            ),
+            ResponseMetric(
+                scenario="large",
+                token_count=0,
+                response_time=0,
+                response_size_bytes=0,
+                contains_low_value_data=False,
+                has_verbose_identifiers=False,
+                error="Transient network error",
+            ),
+        ]
+
+        issues = self.checker._analyze_response_metrics(mock_metrics)
+
+        assert not any(i.issue_type == IssueType.EXECUTION_FAILURE for i in issues)
+
     def test_generate_recommendations(self):
         """Test recommendation generation."""
         issues = [
@@ -370,3 +470,24 @@ class TestTokenEfficiencyChecker:
 
         assert len(recommendations) == 1
         assert "good token efficiency" in recommendations[0].lower()
+
+    def test_generate_recommendations_with_execution_failures(self):
+        """An EXECUTION_FAILURE issue must produce a real recommendation,
+        not the "all tools show good efficiency" fallback (see #14)."""
+        issues = [
+            TokenEfficiencyIssue(
+                tool_name="flaky_tool",
+                issue_type=IssueType.EXECUTION_FAILURE,
+                severity=Severity.ERROR,
+                message="Tool failed to execute in 2/3 test scenarios",
+                suggestion="Check the execution errors above",
+            ),
+        ]
+        stats = {"max_tokens_observed": 0}
+
+        recommendations = self.checker._generate_recommendations(issues, stats)
+
+        assert not any(
+            "good token efficiency" in rec.lower() for rec in recommendations
+        )
+        assert any("failed execution" in rec.lower() for rec in recommendations)


### PR DESCRIPTION
Fixes #14

`_generate_sample_value()` had no handling for schema-declared `enum` constraints, so any enum-only string parameter got a generic `"sample_value"` guess that the server correctly rejects (exactly the `chrome-devtools-mcp` / `throttlingOption` example in the issue). Those failed calls were then silently excluded from analysis (`token_count == 0`), so a tool that failed every scenario just disappeared from the report instead of being flagged — the CLI would print "✅ All tools show good token efficiency!" while having tested almost nothing.

**Changes:**
- `_generate_sample_value()` now returns the first `enum` value when a parameter schema declares one, before falling back to type-based guessing.
- `_analyze_response_metrics()` now emits a new `EXECUTION_FAILURE` issue when ≥50% of a tool's test scenarios fail, so systematic failures are surfaced instead of silently dropped (per the issue's proposed secondary fix).
- `_generate_recommendations()` surfaces `EXECUTION_FAILURE` counts, so the "all tools show good efficiency" fallback message can no longer appear when a tool actually couldn't be tested — traced this through, and the recommendation-empty check is what actually drives that message, not just the enum fix alone.

Scope note: the issue's "enhanced reporting" sub-proposal (tools-analyzed count in the summary table) already exists on `main` in `reports.py`, so I didn't touch that file.

**Testing:** full suite (`pytest tests/`, 148 tests) passes with 80.02% coverage; added 4 new tests covering enum sample generation, the failure-rate threshold (both trigger and no-trigger cases), and the recommendation wiring. `black`/`isort`/`mypy` clean.